### PR TITLE
Improvement/20220922/allowing no shared secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
 RUN wget --quiet --output-document - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && bash -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
-  && apt-get install --yes --no-install-recommends google-chrome-stable=92.0.4515.131-1 \
+  && apt-get install --yes --no-install-recommends google-chrome-stable=105.0.5195.125-1 \
   # Cleaning operations after install
   && apt-get autoremove --yes --purge \
   && apt-get clean \

--- a/app/express-app.js
+++ b/app/express-app.js
@@ -66,7 +66,7 @@ module.exports.expressApp = pages => {
       const secret = req.query.secret
       const url = req.query.url
       const shasum = crypto.createHash('sha256');
-      if(!secret || shasum.update(secret).digest('hex') != secretHash ) {
+      if(secretHash != null && (!secret || shasum.update(secret).digest('hex') != secretHash )) {
         res.status(401)
         res.end('parameter "secret" is not set or you aren\'t authorized')
       }else if (!url) {
@@ -113,7 +113,7 @@ module.exports.expressApp = pages => {
       const html = req.body.html
       const secret = req.body.secret
       const shasum = crypto.createHash('sha256');
-      if(!secret || shasum.update(secret).digest('hex') != secretHash ) {
+      if(secretHash != null && (!secret || shasum.update(secret).digest('hex') != secretHash )) {
         res.status(401)
         res.end('parameter "secret" is not set or you aren\'t authorized')
       }else if (!html) {
@@ -186,7 +186,7 @@ module.exports.expressApp = pages => {
       const url = req.query.url
       const secret = req.query.secret
       const shasum = crypto.createHash('sha256');
-      if(!secret || shasum.update(secret).digest('hex') != secretHash ) {
+      if(secretHash != null && (!secret || shasum.update(secret).digest('hex') != secretHash )) {
         res.status(401)
         res.end('parameter "secret" is not set or you aren\'t authorized')
       }else if (!url) {
@@ -227,7 +227,7 @@ module.exports.expressApp = pages => {
       const html = req.body.html
       const secret = req.body.secret
       const shasum = crypto.createHash('sha256');
-      if(!secret || shasum.update(secret).digest('hex') != secretHash ) {
+      if(secretHash != null && (!secret || shasum.update(secret).digest('hex') != secretHash )) {
         res.status(401)
         res.end('parameter "secret" is not set or you aren\'t authorized')
       }else if (!html) {
@@ -259,7 +259,7 @@ module.exports.expressApp = pages => {
   app.get('/hc', async (req, res) => {
     const secret = req.query.secret
     const shasum = crypto.createHash('sha256');
-    if(!secret || shasum.update(secret).digest('hex') != secretHash ) {
+    if(secretHash != null && (!secret || shasum.update(secret).digest('hex') != secretHash )) {
       res.status(401)
       res.end('parameter "secret" is not set or you aren\'t authorized')
     }else{


### PR DESCRIPTION
I needed to change the chrome package otherwise I was unable to build the image.
The main objective of this change is to allow pdf servers that do not need a shared secret to be configured. Helpful for development and on secure networks (such as docker networks where the server does not expose to outside the network)